### PR TITLE
Set up Gitlab-CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,24 @@
+image: utopianmisfits/elmstatic:latest
+
+stages:
+  - build
+  - deploy
+
+build:
+  stage: build
+  script:
+    - elmstatic build
+  artifacts:
+    paths:
+      - _sites
+
+pages:
+  stage: deploy
+  script:
+    - elmstatic build
+  artifacts:
+    paths:
+    - _sites
+  only:
+    - source
+


### PR DESCRIPTION
Set up Gitlab CI pipelines to deploy the project to Gitlab Pages.
The reason why we're setting Gitlab Pages, is to serve as hosting
redundacy.

This way if by some reason Github goes down, we can still access the
website through Gitlab.